### PR TITLE
chore: add 404 integration tests

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -37,6 +37,11 @@ def get(url, name, client) -> Dict:
     return returned_data
 
 
+def get_assert_status(url, client, status_code) -> None:
+    response = client.get(url)
+    assert response.status_code == status_code
+
+
 def get_all(url, expected_quantity, client):
     response = client.get(url)
 
@@ -66,7 +71,6 @@ def test_end_to_end(client, setup_end_to_end):
         "datanode",
         client,
     )
-
     # Get All
     get_all(url_for("api.scenarios"), 1, client)
     get_all(url_for("api.cycles"), 1, client)
@@ -80,3 +84,11 @@ def test_end_to_end(client, setup_end_to_end):
     delete(url_for("api.pipeline_by_id", pipeline_id=pipeline.get("id")), client)
     delete(url_for("api.task_by_id", task_id=task.get("id")), client)
     delete(url_for("api.datanode_by_id", datanode_id=datanode.get("id")), client)
+
+    # Check status code
+    # Non-existing entities should return 404
+    get_assert_status(url_for("api.cycle_by_id", cycle_id=9999999), client, 404)
+    get_assert_status(url_for("api.scenario_by_id", scenario_id=9999999), client, 404)
+    get_assert_status(url_for("api.pipeline_by_id", pipeline_id=9999999), client, 404)
+    get_assert_status(url_for("api.task_by_id", task_id=9999999), client, 404)
+    get_assert_status(url_for("api.datanode_by_id", datanode_id=9999999), client, 404)


### PR DESCRIPTION
This PR is related to #103 reported by florian. I couldn't reproduce the error, but I've added some integration testing for 404s when the entities don't exist. The way that taipe-rest handles 404 is by checking raised exceptions on the file `src/taipy/rest/api/error_handler.py`, so in case is a exception not expected it could lead to the behavior described in the issue. @florian-vuillemot do you remember what was the stacktrace? Maybe it could give us a clue on what's wrong. If theres anything else to add I can add on this PR in case we can isolate the problem.